### PR TITLE
upper casing Kiysha's email address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ people:
 - name: Kiysha Ramey-Jenkins
   pic: k
   position: Associate Director
-  email: kiysha@tmcdc.org
+  email: Kiysha@tmcdc.org
 #   social:
 #     - title: twitter
 #       url: #


### PR DESCRIPTION
Office365 might enforce exact match on email.  On Office365 it is "Kiysha@tmcdc.org" but I put "kiysha@tmcdc.org".